### PR TITLE
Allows PMs for bot commands

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ client.on('message', (message) => {
     } else {
       const handler = detectHandler(message.content)
       if (handler){
-        // Checks if channel is #bot-commands-here or message is NOT from guild
+        // Checks if channel is #bot-commands or message is NOT from guild
         if ((message.channel.id === '762377613062701146') || (message.guild === null)) {
           handler(message)
           log(

--- a/src/index.js
+++ b/src/index.js
@@ -37,15 +37,17 @@ client.on('message', (message) => {
     } else {
       const handler = detectHandler(message.content)
       if (handler){
-        if (message.channel.id !== '762377613062701146') {
+        // Checks if channel is #bot-commands-here or message is NOT from guild
+        if ((message.channel.id === '762377613062701146') || (message.guild === null)) {
+          handler(message)
+          log(
+            `Served command ${message.content} successfully for ${message.author.username}.`,
+          )
+        } else {
           message.delete({ timeout: 500 })
           message.author.send(wrongChannelWarningEmbed())
           return
         }
-        handler(message)
-        log(
-          `Served command ${message.content} successfully for ${message.author.username}.`,
-        )
       }
     }
   } catch (err) {


### PR DESCRIPTION
Users can now PM the bot as well, rather than only using the channel #bot-commands

(I realized after doing this that this probably shouldn't have required a branch and that I should've probably used the fork for this?)