### PR TITLE
fix: bot no longer removes reactions from other bots.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ client.on('guildMemberAdd', (member) => {
 
 // Listen for reactions
 client.on('messageReactionAdd', async (reaction, user) => {
+  if (reaction.message.author.bot) return
   // check if not yet cached
   if (reaction.partial) {
     try {


### PR DESCRIPTION
This is a quick fix that needs to be made so tip.cc bot can work as it should.