### PR TITLE
updated welcome dm embed

### DIFF
--- a/src/embed.js
+++ b/src/embed.js
@@ -13,7 +13,7 @@ function welcomeEmbed() {
         },
         {
           name: 'Frequently Asked Questions (FAQ) ❓',
-          value: 'https://hackmd.io/ObCMUJUxTumG2z6FJ5cnkg',
+          value: 'https://1hive.gitbook.io/1hive/guides/faq',
         },
         {
           name: 'Get free honey 🤑',
@@ -25,20 +25,23 @@ function welcomeEmbed() {
         },
         {
           name: 'Learn more about Honey (HNY) 🍯',
-          value: 'https://blog.1hive.org/honey/',
+          value: 'https://1hive.gitbook.io/1hive/projects/honey',
         },
         {
           name: 'Announcements and recaps of all the things 📰',
-          value: 'https://1hive.substack.com/ ',
+          value: 'https://1hive.gitbook.io/1hive/projects/milestones ',
         },
         {
           name: 'Documentation of our DAO 📝',
-          value: 'https://about.1hive.org/docs/dao/',
+          value: 'https://1hive.gitbook.io/1hive/',
         },
         {
-          name: 'Detailed description all of our channels',
-          value:
-            'https://discordapp.com/channels/698287700834517064/758821739202347038/758886904078008363',
+          name: 'Detailed description of all of our channels ℹ️',
+          value: 'https://1hive.gitbook.io/1hive/getting-started/discord#channels',
+        },
+        {
+          name: 'Our community covenant',
+          value: 'https://1hive.gitbook.io/1hive/community-covenant',
         },
       ],
       timestamp: new Date(),

--- a/src/embed.js
+++ b/src/embed.js
@@ -4,7 +4,7 @@ function welcomeEmbed() {
     embed: {
       title: 'Welcome to 1Hive! 🍯',
       description:
-        'Please say hi in #:wave:intros to share how you found us and what interests you!',
+        'Please say hi in [#:coffee:cafe](https://discord.com/channels/698287700834517064/708187392594411521) to share how you found us and what interests you!\nYou could also head over to [Introduce yourself to 1Hive thread](https://forum.1hive.org/t/introduce-yourself-to-1hive-thread/130)-!',
       color: 16769024,
       fields: [
         {

--- a/src/embed.js
+++ b/src/embed.js
@@ -4,7 +4,7 @@ function welcomeEmbed() {
     embed: {
       title: 'Welcome to 1Hive! 🍯',
       description:
-        'Please say hi in [#:coffee:cafe](https://discord.com/channels/698287700834517064/708187392594411521) to share how you found us and what interests you!\nYou could also head over to [Introduce yourself to 1Hive thread](https://forum.1hive.org/t/introduce-yourself-to-1hive-thread/130)-!',
+        'Please say hi in [#:coffee:cafe](https://discord.com/channels/698287700834517064/708187392594411521) to share how you found us and what interests you!\nYou could also head over to [Introduce yourself to 1Hive thread](https://forum.1hive.org/t/introduce-yourself-to-1hive-thread/130)!',
       color: 16769024,
       fields: [
         {


### PR DESCRIPTION
The embed referred to an old channel for intros, title #:wave:intros, which seems to be a deleted channel on the discord server. #:coffee:cafe seems to be the equivalent of such a channel(not sure tho). 


Also, linked to the introduce-yourself forum in the bot embed.

## Which file was altered?
`src/embeds.js`

## What has been updated?
All the outdated links have been replaced with links from the 1hive wiki.
A new field, linking to community covenant has been added.

## Related issue:
closes #37