### PR TITLE
Updated '!hny official' embed to include all social accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ There are a few other scripts provided:
 
 ### Configuration
 
+First, install the dependencies:
+`npm install`
+`npm install -D`
+
 For the bot to run properly, it needs these variables, laid out in the `.env.sample` file:
 
 - `DISCORD_API_TOKEN`: Your discord API token. [See this guide on how to obtain one](https://github.com/reactiflux/discord-irc/wiki/Creating-a-discord-bot-&-getting-a-token).
+- `WEB3_URL`: You can use `ws://localhost:8545` to run the bot locally.
+- `CHANNEL_ID`: Your Server Channel ID.

--- a/src/embed.js
+++ b/src/embed.js
@@ -619,25 +619,25 @@ function officialAccountsEmbed() {
         url: 'https://audiologydesign.com/wp-content/uploads/2017/05/header-social.jpg',
       },
       color: 16769024,
-      description: `
-        - [Instagram - 1Hive](https://www.instagram.com/honeyswap.1hive/)
-        - [Instagram - 1Hive in Spanish](https://www.instagram.com/honeyswap.1hive_es/)
-        - [Instagram - Honeyswap](https://www.instagram.com/honeyswap/)
-        - [Twitter - 1Hive](https://twitter.com/1HiveOrg)
-        - [Twitter - Honeyswap](https://twitter.com/Honeyswap)
-        - [Twitter - Honeyswap in Chinese](https://twitter.com/HoneySwap_CN)
-        - [Twitter - Honeyswap in Spanish](https://twitter.com/HoneyswapEs)
-        - [Twitter - Honeyswap in Hindi](https://twitter.com/honeyswap_IN)
-        - [Reddit](https://www.reddit.com/r/HNY/)
-        - [Facebook](https://www.facebook.com/honeyswapdex/)
-        - [Telegram](https://t.me/honeyswapDEX)
-        - [YouTube](https://www.youtube.com/channel/UCg0yASRY6TmXDryitYvsJOQ)
-        - [Medium - 1Hive](https://medium.com/1hive)
-        - [Medium - Honeyswap](https://medium.com/honeyswap)
-        - [Blog](https://about.1hive.org/blog/)
-        - [Wechat](https://bit.ly/38UuWeJ)
-        - Kuaishou: honeyswap
-      `,
+      description: [
+        '- [Instagram - 1Hive](https://www.instagram.com/honeyswap.1hive/)\n',
+        '- [Instagram - 1Hive in Spanish](https://www.instagram.com/honeyswap.1hive_es/)\n',
+        '- [Instagram - Honeyswap](https://www.instagram.com/honeyswap/)\n',
+        '- [Twitter - 1Hive](https://twitter.com/1HiveOrg)\n',
+        '- [Twitter - Honeyswap](https://twitter.com/Honeyswap)\n',
+        '- [Twitter - Honeyswap in Chinese](https://twitter.com/HoneySwap_CN)\n',
+        '- [Twitter - Honeyswap in Spanish](https://twitter.com/HoneyswapEs)\n',
+        '- [Twitter - Honeyswap in Hindi](https://twitter.com/honeyswap_IN)\n',
+        '- [Reddit](https://www.reddit.com/r/HNY/)\n',
+        '- [Facebook](https://www.facebook.com/honeyswapdex/)\n',
+        '- [Telegram](https://t.me/honeyswapDEX)\n',
+        '- [YouTube](https://www.youtube.com/channel/UCg0yASRY6TmXDryitYvsJOQ)\n',
+        '- [Medium - 1Hive](https://medium.com/1hive)\n',
+        '- [Medium - Honeyswap](https://medium.com/honeyswap)\n',
+        '- [Blog](https://about.1hive.org/blog/)\n',
+        '- [Wechat](https://bit.ly/38UuWeJ)\n',
+        '- Kuaishou: honeyswap\n'
+      ].join(''),
       timestamp: new Date(),
       footer: {
         text: 'info.honeyswap.org',

--- a/src/embed.js
+++ b/src/embed.js
@@ -619,25 +619,25 @@ function officialAccountsEmbed() {
         url: 'https://audiologydesign.com/wp-content/uploads/2017/05/header-social.jpg',
       },
       color: 16769024,
-      fields: [
-        {
-          name: 'Reddit',
-          value: `http://reddit.com/r/HNY `,
-        },
-        {
-          name: 'Twitter',
-          value: `https://twitter.com/Honeyswap`,
-        },
-        {
-          name: 'Telegram',
-          value: `https://t.me/honeyswapofficial`,
-        },
-        {
-          name: 'Youtube',
-          value: `https://www.youtube.com/channel/UCDgC-6bMv9YxJZJGuItr3NQ`,
-
-        },
-      ],
+      description: `
+        - [Instagram - 1Hive](https://www.instagram.com/honeyswap.1hive/)
+        - [Instagram - 1Hive in Spanish](https://www.instagram.com/honeyswap.1hive_es/)
+        - [Instagram - Honeyswap](https://www.instagram.com/honeyswap/)
+        - [Twitter - 1Hive](https://twitter.com/1HiveOrg)
+        - [Twitter - Honeyswap](https://twitter.com/Honeyswap)
+        - [Twitter - Honeyswap in Chinese](https://twitter.com/HoneySwap_CN)
+        - [Twitter - Honeyswap in Spanish](https://twitter.com/HoneyswapEs)
+        - [Twitter - Honeyswap in Hindi](https://twitter.com/honeyswap_IN)
+        - [Reddit](https://www.reddit.com/r/HNY/)
+        - [Facebook](https://www.facebook.com/honeyswapdex/)
+        - [Telegram](https://t.me/honeyswapDEX)
+        - [YouTube](https://www.youtube.com/channel/UCg0yASRY6TmXDryitYvsJOQ)
+        - [Medium - 1Hive](https://medium.com/1hive)
+        - [Medium - Honeyswap](https://medium.com/honeyswap)
+        - [Blog](https://about.1hive.org/blog/)
+        - [Wechat](https://bit.ly/38UuWeJ)
+        - Kuaishou: honeyswap
+      `,
       timestamp: new Date(),
       footer: {
         text: 'info.honeyswap.org',


### PR DESCRIPTION
### What was the problem?
- Bot embed was listing some old social accounts and there were some other missing.

### Changes:
- Changed the embed format so it doesn't take that much screen.
- Readme was updated to include some ENV variables missing that are necessary for the bot to run.

Before the change:
![Screenshot from 2021-01-31 22-47-55](https://user-images.githubusercontent.com/22449631/106405980-ab3ea680-6416-11eb-916e-f9feef96e588.png)

After the change (run locally):
![Screenshot from 2021-01-31 22-50-54](https://user-images.githubusercontent.com/22449631/106406051-d9bc8180-6416-11eb-89ab-600064011e18.png)
