### PR TITLE
Feat: bot updates activity description with HNY price

### DIFF
--- a/src/handlers/price.js
+++ b/src/handlers/price.js
@@ -23,6 +23,9 @@ module.exports = async function honeyPrice(message) {
 
   const { pair } = result.data
   const hnyPrice = parseFloat(pair.token1Price).toFixed(2)
-  message.channel.send(`<@${message.author.id}>`)
-  message.channel.send(honeyPriceEmbed(hnyPrice))
+  
+  if (message) {
+    message.channel.send(`<@${message.author.id}>`)
+    message.channel.send(honeyPriceEmbed(hnyPrice))
+  } else return hnyPrice
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const dotenv = require('dotenv')
 const detectHandler = require('./parser/detectHandler')
 const { RequestHandlerError } = require('./error-utils')
 const { log } = require('./utils')
+const fetchPrice = require('./handlers/price')
 
 const {
   welcomeEmbed,
@@ -112,5 +113,10 @@ client.on('message', (message) => {
     // Sentry.captureException(err)
   }
 })
+
+client.setInterval(async () => {
+  const price = await fetchPrice()
+  await client.user.setActivity(`HNY price: $${price}`, { type: 'WATCHING' })
+}, 1 * 60 * 1000)
 
 client.login(process.env.DISCORD_API_TOKEN)


### PR DESCRIPTION
### Description:
Updated bot so now it also displays HNY price on its user activity description.

### Changes:
- `src/handlers/price.js`: updated the function so it now detects if it's called from a message or not to decide whether to send the embed or just return the price.
- `src/index.js`: added a `setInterval` function to fetch HNY price and update bot's activity description every 1 minute.

### Change preview (run locally):
![Screenshot from 2021-02-05 18-38-59](https://user-images.githubusercontent.com/22449631/107092017-7e590d80-67e1-11eb-8085-8b36bb9a8d99.png)
