### PR TITLE
Bug fix: Bot does not crash anymore when receiving DM

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,10 +68,12 @@ client.on('message', (message) => {
   if (message.author.bot) return
 
   // Gets the Bot-commands channel ID.
-  const BOT_COMMANDS_CHANNEL_ID = message.guild.channels.cache.find(channel => {
-    return channel.name.includes('bot-commands')
-  }).id
-  
+  const BOT_COMMANDS_CHANNEL_ID = message.channel.type === 'dm' 
+    ? message.channel.id
+    : message.guild.channels.cache.find(channel => {
+      return channel.name.includes('bot-commands')
+    }).id
+    
   try {
     if (message.content.includes('app.brightid.org/connection-code')) {
       // Deletes the message inmediately.


### PR DESCRIPTION
### Description

With PR #42 was introduced a bug that made the app crash every time the bot received a DM because it could not find the Bot-commands channel, this PR solves the issue by first checking if the message's channel is on DM or on a Guild (server) before searching for the Bot-commands channel.